### PR TITLE
Correction: mark plausible as an open-source tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ These Firefox extensions can help prevent connections to Google domains and also
   - [Noblogs](https://noblogs.org/) - **9-eyes** - A privacy/security focused blogging platform.
 - Analytics
   - [Matomo](https://matomo.org/) - **9/14-eyes** (Matomo/parent company) - Open-source analytics platform. (thanks u/Newblik)
-  - [Plausible](https://plausible.io/) - **5-eyes** - Not open-source, but privacy-focused web analytics.
+  - [Plausible](https://plausible.io/) - **5-eyes** - Open-source, privacy-focused web analytics.
 - Photos
   - [Piwigo](https://piwigo.org/) - **9-eyes** (self-hosted) - Self-hosted and open-source cloud photo manager. You can also sign up for an ["as a service" account](https://piwigo.com).
   - *Help requested!*


### PR DESCRIPTION
I'm the author of Plausible. I think this list was created before I open-sourced the whole codebase in Sept 2019. Anyways, the project is now [open-source](https://github.com/plausible-insights/plausible) so I thought I'd correct it.