### PR TITLE
Add google-webfonts-helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ These Firefox extensions can help prevent connections to Google domains and also
   - Thanks to u/eA8KESARaW6iqCpHsbE4 for suggesting Jellyfin and pointing out that Emby isn't open-source.
 - Fonts
   - [Open Font Library](https://fontlibrary.org/) - **5-eyes** - Lots of Serif and Sans-Serif fonts that can be directly embedded into a website.
+  - [google webfonts helper](https://google-webfonts-helper.herokuapp.com/fonts) - **5-eyes** - Hassle-free way for webmasters to self-host open-source Fonts from "Google Fonts"
 - Classroom
   - *Help requested!*
 - Maps/Street View


### PR DESCRIPTION
A practical service that empowers webmaster to self-host open source fonts that normally live at "Google Fonts"