### PR TITLE
Add TrackMeNot to obfuscate search queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ These Firefox extensions can help prevent connections to Google domains and also
   - [Skip Redirect](https://addons.mozilla.org/en-US/firefox/addon/skip-redirect/)
   - [Temporary Containers](https://addons.mozilla.org/en-US/firefox/addon/temporary-containers/)
 - [uMatrix](https://addons.mozilla.org/en-US/firefox/addon/umatrix/) (thanks u/rudolf323)
+- [TrackMeNot](https://addons.mozilla.org/en-US/firefox/addon/trackmenot/)
 
 # Replacements/alternatives
 ## Notes, disclaimers, and rules


### PR DESCRIPTION
http://trackmenot.io/

TrackMeNot is an extension for Firefox and Chrome browsers that helps keep privacy by obfuscating search queries made on various search engines (Google, Yahoo, Bing, etc.).
It makes random search queries to hide what you normally search for and will also make additional queries that are modified from your original one to hide your real intent.