### PR TITLE
Add AdNauseam to list of Firefox extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ These Firefox extensions can help prevent connections to Google domains and also
   - [Skip Redirect](https://addons.mozilla.org/en-US/firefox/addon/skip-redirect/)
   - [Temporary Containers](https://addons.mozilla.org/en-US/firefox/addon/temporary-containers/)
 - [uMatrix](https://addons.mozilla.org/en-US/firefox/addon/umatrix/) (thanks u/rudolf323)
+- [AdNauseam](https://addons.mozilla.org/en-US/firefox/addon/adnauseam/)
 
 # Replacements/alternatives
 ## Notes, disclaimers, and rules


### PR DESCRIPTION
AdNauseam is a fork of uBlock Origin.

AdNauseam not only blocks ads, it obfuscates browsing data to resist tracking by the online ad industry. To throw ad networks off your trail, AdNauseam can be set to “click” blocked ads, further polluting a users' data profile and frustrating those who engage in bulk surveillance and profiling. The extension’s interactive AdVault feature allows users to visualize and explore all the ads that AdNauseam has captured.