### PR TITLE
Add CodeFund as Google Ads alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ These Firefox extensions can help prevent connections to Google domains and also
   - [DeepL](https://deepl.com/) - **14-eyes** - DeepL is an artifical intelligence translation service. *Editor note: The site server seems to be hosted in Finland, yet the company lists itself as [a company based in Germany](https://www.deepl.com/pro-faq.html) in the Data Protection section.*
   - *Help requested!*
 - Google Ads/AdMob/AdSense
+  - [CodeFund](https://codefund.io/) -- **5-eyes** - ethical advertising for technical audience.
   - *Help requested!*
 - Google Alerts
   - *Help requested!*


### PR DESCRIPTION
https://codefund.io

AFAIK this is the best alternative out there. Their privacy policy:

https://www.iubenda.com/privacy-policy/47597768