### PR TITLE
Add resources to justify degoogling

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,6 +29,7 @@ GitHub:
 - [@NicolasPA](https://github.com/NicolasPA)
 - [@Glitchy-Tozier](https://github.com/Glitchy-Tozier)
 - [@scribblemaniac](https://github.com/scribblemaniac)
+- [@br3ndonland](https://github.com/br3ndonland)
 
 Reddit:
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,29 @@ Everything you need to become a Privacy Wizard.
 - [J. Nathan Matias | Blog 20181208: Quitting Facebook & Google](https://medium.com/@natematias/https-medium-com-natematias-quitting-facebook-google-aaf8f4c80fbf)
 - [Marko Saric | Blog 20191205: How to fight back against Google AMP as a web user and a web developer](https://markosaric.com/google-amp/)
 
+## News articles
+
+- [Forbes | 20120515: Google can survive too much innovation. You can’t.](https://www.forbes.com/sites/forbesleadershipforum/2012/05/15/google-can-survive-too-much-innovation-you-cant/#37ff02f66003)
+- [Business Insider | 20150417: The truth about Google’s famous ’20% time’ policy](https://www.businessinsider.com/google-20-percent-time-policy-2015-4)
+- [The Atlantic | 20161101: The binge breaker](https://www.theatlantic.com/magazine/archive/2016/11/the-binge-breaker/501122/)
+- [WIRED | 20170922: How malware keeps sneaking past Google Play’s defenses](https://www.wired.com/story/google-play-store-malware/)
+- [MIT Technology Review | 20171003: Forget killer robots - bias is the real AI danger](https://www.technologyreview.com/s/608986/forget-killer-robotsbias-is-the-real-ai-danger/)
+- [Business Insider | 20180108: Google managers kept blacklists of conservative employees and one manager considered holding ‘trials,’ a new lawsuit alleges](https://www.businessinsider.com/conservative-google-employees-are-blacklisted-lawsuit-alleges-2018-1)
+- [CNBC | 20180124: A longtime Google engineer quits, saying the company is now ‘100% competitor-focused’](https://www.cnbc.com/2018/01/24/google-engineer-steve-yege-calls-company-100-percent-competitor-focused.html)
+- [Washington Post | 20180126: Facebook and Google are doomed, George Soros says](https://www.washingtonpost.com/news/the-switch/wp/2018/01/26/facebook-and-google-are-doomed-george-soros-says/)
+- [Gizmodo | 20180326: Google isn’t listening, so its employees are suing](https://gizmodo.com/google-isnt-listening-so-its-employees-are-suing-1823611720)
+- [The Guardian | 20180328: Google sees major claims of harassment and discrimination as lawsuits proceed](https://www.theguardian.com/technology/2018/mar/28/google-sexual-harassment-pay-gap-lawsuits-proceed)
+- [CNBC | 20180511: How to stop Google from tracking everything you do online](https://www.cnbc.com/2018/05/11/how-to-stop-google-from-tracking-me-online.html)
+- [Engadget | 20180524: Google will always do evil](https://www.engadget.com/2018/05/24/google-will-always-do-evil/)
+- [TechCrunch | 20180607: Google’s new ‘AI principles’ forbid its use in weapons and human rights violations](https://techcrunch.com/2018/06/07/googles-new-ai-principles-forbid-its-use-in-weapons-and-human-rights-violations/)
+- [The Intercept | 20180801: Google plans to launch censored search engine in China, leaked documents reveal](https://theintercept.com/2018/08/01/google-china-search-engine-censorship/)
+- [Washington Post | 20180809: Opinion - Google’s China plan isn’t just evil - it’s bad for business](https://www.washingtonpost.com/opinions/global-opinions/googles-china-plan-isnt-just-evil--its-bad-for-business/2018/08/09/143046be-9c12-11e8-8d5e-c6c594024954_story.html)
+- [The New York Times | 20181025: How Google protected Andy Rubin, the ‘Father of Android’](https://www.nytimes.com/2018/10/25/technology/google-sexual-harassment-andy-rubin.html)
+- [WIRED | 20181210: A new Google+ blunder exposed data from 52.5 million users](https://www.wired.com/story/google-plus-bug-52-million-users-data-exposed/)
+- [WIRED | 20190813: Three years of misery inside Google, the happiest company in tech](https://www.wired.com/story/inside-google-three-years-misery-happiest-company-tech/)
+- [TechCrunch | 20200123: Google’s latest user-hostile design change makes ads and search results look identical](https://techcrunch.com/2020/01/23/squint-and-youll-click-it/)
+- [The New York Times | 20200124: You are now remotely controlled](https://www.nytimes.com/2020/01/24/opinion/sunday/surveillance-capitalism.html)
+
 # The lighter side
 
 - Movies and TV I recommend:

--- a/README.md
+++ b/README.md
@@ -391,7 +391,9 @@ When searching for replacements, check the alternative stores (such as F-Droid) 
 
 # Useful links, tools, and advice
 
-Everything you need to become Privacy Wizard.
+## Resources
+
+Everything you need to become a Privacy Wizard.
 
 - [Privacy Tools](https://www.privacytools.io/) (thanks u/yieldingTemporarily)
 - [ethical.net](https://ethical.net/) (thanks u/yieldingTemporarily)

--- a/README.md
+++ b/README.md
@@ -429,6 +429,11 @@ Everything you need to become a Privacy Wizard.
 - Check out [WindowsSpyBlocker](https://github.com/crazy-max/WindowsSpyBlocker) and [this tutorial](https://github.com/adolfintel/Windows10-Privacy) for even more Windows 10 tips (thanks u/rudolf323)
 - Did you read the [wiki](https://old.reddit.com/r/privacy/wiki/index) yet? Go do that.
 
+## Books
+
+- [Jaron Lanier | Ten arguments for deleting your social media accounts right now](http://www.jaronlanier.com/tenarguments.html) (2018)
+- [Shoshana Zuboff | The age of surveillance capitalism: The fight for a human future at the new frontier of power](https://www.publicaffairsbooks.com/titles/shoshana-zuboff/the-age-of-surveillance-capitalism/9781610395694/) (2019)
+
 # The lighter side
 
 - Movies and TV I recommend:

--- a/README.md
+++ b/README.md
@@ -434,6 +434,12 @@ Everything you need to become a Privacy Wizard.
 - [Jaron Lanier | Ten arguments for deleting your social media accounts right now](http://www.jaronlanier.com/tenarguments.html) (2018)
 - [Shoshana Zuboff | The age of surveillance capitalism: The fight for a human future at the new frontier of power](https://www.publicaffairsbooks.com/titles/shoshana-zuboff/the-age-of-surveillance-capitalism/9781610395694/) (2019)
 
+## Blog posts
+
+- [Electronic Frontier Foundation | Blog 20181101: Google Chrome’s users take a back seat to its bottom line](https://www.eff.org/deeplinks/2018/11/google-chromes-users-take-back-seat-its-bottom-line)
+- [J. Nathan Matias | Blog 20181208: Quitting Facebook & Google](https://medium.com/@natematias/https-medium-com-natematias-quitting-facebook-google-aaf8f4c80fbf)
+- [Marko Saric | Blog 20191205: How to fight back against Google AMP as a web user and a web developer](https://markosaric.com/google-amp/)
+
 # The lighter side
 
 - Movies and TV I recommend:

--- a/README.md
+++ b/README.md
@@ -413,7 +413,6 @@ Everything you need to become a Privacy Wizard.
 - [HTTP vs. HTTPS](https://outline.com/xUXZMh)
 - The EFF has an [excellent guide](https://ssd.eff.org/) on how to stay safe and secure online. It is incredibly useful and I suggest that everyone read through it.
 - Click [here](https://www.thewindowsclub.com/windows-10-telemetry) and [here](https://winaero.com/blog/how-to-disable-telemetry-and-data-collection-in-windows-10/) for tips on disabling Windows 10 telemetry/data collection.
-- Click [here](https://www.mozilla.org/en-US/internet-health/privacy-security/) and [here](https://blog.mozilla.org/internetcitizen/2017/01/30/15-privacy-tips-protect-online-life/) for tips from the Mozilla Foundation on internet privacy and security.
 - Click [here](https://duckduckgo.com/newsletter) to sign up for DuckDuckGo's privacy newsletter, and [here](https://spreadprivacy.com/) for more tips, articles, and blog posts from DuckDuckGo.
 - [Delete Facebook](https://deletefacebook.com/). Another guide can be found [here](https://www.wikihow.com/Permanently-Delete-a-Facebook-Account).
 - [Why you should put tape over your webcam](https://outline.com/fYCu98)
@@ -439,6 +438,7 @@ Everything you need to become a Privacy Wizard.
 - [Electronic Frontier Foundation | Blog 20181101: Google Chrome’s users take a back seat to its bottom line](https://www.eff.org/deeplinks/2018/11/google-chromes-users-take-back-seat-its-bottom-line)
 - [J. Nathan Matias | Blog 20181208: Quitting Facebook & Google](https://medium.com/@natematias/https-medium-com-natematias-quitting-facebook-google-aaf8f4c80fbf)
 - [Marko Saric | Blog 20191205: How to fight back against Google AMP as a web user and a web developer](https://markosaric.com/google-amp/)
+- Click [here](https://www.mozilla.org/en-US/internet-health/privacy-security/) and [here](https://blog.mozilla.org/internetcitizen/2017/01/30/15-privacy-tips-protect-online-life/) for tips from the Mozilla Foundation on internet privacy and security.
 
 ## News articles
 


### PR DESCRIPTION
Thanks for putting this repo together. I successfully degoogled last year. I haven't missed Google at all, and I’m happy to help others degoogle as well.

It would be good to provide some resources to justify degoogling. *Why should people go to all this trouble degoogling, when Google products are so convenient?*

I added some news articles, blog posts, and books on the topic that can help people make an informed decision. It’s not an exhaustive library of information about Google, just a selection that highlights some of the issues. I have avoided opinionated statements in this section, and have just provided resources for people to make up their own minds.

When I clip articles to my notes app, I title them with this format, which helps sort the articles: `Source | YYYYMMDD: Title in title case`. Happy to change it if you prefer a different format.

I would love to see some people add blog posts about their experiences degoogling. I plan to write one soon!