### PR TITLE
Updated 'What are 5-eyes, 9-eyes, and 14-eyes?'

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ These Firefox extensions can help prevent connections to Google domains and also
     - **5**: Australia, Canada, New Zealand, UK, USA
     - **9**: Denmark, France, Netherlands, Norway
     - **14**: Germany, Belgium, Italy, Sweden, Spain
-    - [What are 5-eyes, 9-eyes, and 14-eyes?](https://restoreprivacy.com/5-eyes-9-eyes-14-eyes/)
+    - [What are 5-eyes, 9-eyes, and 14-eyes?](https://www.privacytools.io/providers/#ukusa)
 
 ## Web-based products
 


### PR DESCRIPTION
Currently, this links to restoreprivacy.com - a site known for [misinformation](https://restoreprivacy.com/tor/) and having [affiliates](https://restoreprivacy.com/best-vpn/). [PrivacyTools](https://www.privacytools.io/) is much more advanced, with a GitHub repo with issues in a similar style to here and hence the link should be replaced.