### PR TITLE
EteSync: add the contacts (was already in calendar and tasks)

### DIFF
--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -968,6 +968,11 @@ mobile applications:
       fdroid: opencontacts.open.com.opencontacts
       text: |
         Open source contacts. (thanks u/consentio)
+    - name: EteSync
+      url: https://www.etesync.com
+      eyes: null
+      text: |
+        Secure, end-to-end encrypted, and open-source sync for your contacts, calendars and tasks.
   messages:
     - title: Android Messages (specifically SMS/MMS, not IM)
     - name: QKSMS

--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -970,6 +970,7 @@ mobile applications:
         Open source contacts. (thanks u/consentio)
     - name: EteSync
       url: https://www.etesync.com
+      fdroid: com.etesync.syncadapter
       eyes: null
       text: |
         Secure, end-to-end encrypted, and open-source sync for your contacts, calendars and tasks.


### PR DESCRIPTION
For some reason EteSync wasn't listed under contacts (I guess the category was added
after EteSync was already on the list).
EteSync is already under calendar and tasks, this commit adds EteSync under contacts too.