### PR TITLE
Add Fastmail to calendar section, remove 'big M' #210

### DIFF
--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -300,6 +300,11 @@ web based products:
       eyes: null
       text: |
         Nextcloud also offers a calendar solution using CalDAV and CardDAV. Thanks @mahdi1234 for pointing this out.
+    - name: Fastmail
+      url: https://fastmail.com/
+      eyes: 5
+      text: |
+        Paid email provider with Calendar hosting using CalDAV and CardDAV, located in Australia and US.
   docs:
     - title: Docs/Sheets/Slides (cloud)
     - name: CryptPad
@@ -514,7 +519,7 @@ web based products:
       eyes: null
       text: |
         Paid email provider, located in Switzerland. Focus on privacy.
-    - name: FastMail
+    - name: Fastmail
       url: https://fastmail.com/
       eyes: 5
       text: |


### PR DESCRIPTION
Fastmail also provides calendaring services, and no longer uses the "Big M" since it was creating too much confusion.