### PR TITLE
Only add Markdown table headers if there is data to be displayed

### DIFF
--- a/_build.js
+++ b/_build.js
@@ -105,7 +105,8 @@ function generateServiceSection(data) {
     let notes = os.EOL + '';
     // If there is data to be displayed, add the start of a Markdown table
     let tableHeader = `| Name | Eyes | Description |${os.EOL}| ---- | ---- | ----------- |${os.EOL}`;
-    if (data.filter(d => "name" in d).length > 0) serviceSection = serviceSection.concat(tableHeader);
+    if (data.filter(d => 'name' in d).length == 0) tableHeader = `No known alternatives.${os.EOL}`;
+    serviceSection = serviceSection.concat(tableHeader);
     // Iterate over each alternative service and add it to the table
     data.forEach(item => {
         // If the object has length one, it's either title or note

--- a/_build.js
+++ b/_build.js
@@ -100,9 +100,12 @@ function generateCategorySection(header, data) {
  * @param {Array} data
  */
 function generateServiceSection(data) {
-    // Start the section with an <h4> header and the start of a Markdown table
-    let serviceSection = `#### ${data[0].title + os.EOL + os.EOL}| Name | Eyes | Description |${os.EOL}| ---- | ---- | ----------- |${os.EOL}`;
+    // Start the section with an <h4> header
+    let serviceSection = `#### ${data[0].title + os.EOL + os.EOL}`;
     let notes = os.EOL + '';
+    // If there is data to be displayed, add the start of a Markdown table
+    let tableHeader = `| Name | Eyes | Description |${os.EOL}| ---- | ---- | ----------- |${os.EOL}`;
+    if (data.filter(d => "name" in d).length > 0) serviceSection = serviceSection.concat(tableHeader);
     // Iterate over each alternative service and add it to the table
     data.forEach(item => {
         // If the object has length one, it's either title or note


### PR DESCRIPTION
Removes table headers if there are no items with `name`s to add.

Alternatively, could replace with a "No alternatives known" text, up to @tycrek