### PR TITLE
Update Sync to include 5-eyes

### DIFF
--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -425,7 +425,7 @@ web based products:
         Primarily meant for businesses, but offers a free version for individuals as well. (thanks u/xNick26)
     - name: Sync
       url: https://www.sync.com
-      eyes: null
+      eyes: 5
       text: |
         End-to-end encrypted Google Drive/Dropbox replacement.
     - name: JottaCloud


### PR DESCRIPTION
This PR references Issue #263.

Sync.com is based in Canada, which is a part of 5-eyes, so it should be labelled as such.

Resources:
https://www.sync.com/about/
https://www.sync.com/download/sync_fact_sheet.pdf