### PR TITLE
VirusTotal is owned by Google - remove it

### DIFF
--- a/md/_resources.md
+++ b/md/_resources.md
@@ -33,5 +33,5 @@ Everything you need to become a Privacy Wizard.
 - [Guide for Linux users](https://github.com/wesaphzt/block-all-google) on blocking everything Google at the network level. This can and probably will break other alternatives that rely on Google to serve content. Thanks u/wesaphzt
 - u/wesaphzt also provided [this](https://github.com/pyllyukko/user.js), [this](https://ffprofile.com/), and [this](https://www.privacytools.io/browsers/#about_config) for hardening Firefox.
 - Check out [WindowsSpyBlocker](https://github.com/crazy-max/WindowsSpyBlocker) and [this tutorial](https://github.com/adolfintel/Windows10-Privacy) for even more Windows 10 tips (thanks u/rudolf323)
-- [Virustotal](https://www.virustotal.com/) let's you upload files and it scans it against multiple antivirus software at once. Very helpful for checking false negatives. Website uses Google Analytics.
+- [Virustotal](https://www.virustotal.com/) let you upload files and it scans it against multiple antivirus software at once. Very helpful for checking false negatives. Unfortunately, Alphabet Inc owns VirusTotal, but there are no good alternatives.
 - Did you read the [wiki](https://old.reddit.com/r/privacy/wiki/index) yet? Go do that.

--- a/md/_resources.md
+++ b/md/_resources.md
@@ -33,4 +33,5 @@ Everything you need to become a Privacy Wizard.
 - [Guide for Linux users](https://github.com/wesaphzt/block-all-google) on blocking everything Google at the network level. This can and probably will break other alternatives that rely on Google to serve content. Thanks u/wesaphzt
 - u/wesaphzt also provided [this](https://github.com/pyllyukko/user.js), [this](https://ffprofile.com/), and [this](https://www.privacytools.io/browsers/#about_config) for hardening Firefox.
 - Check out [WindowsSpyBlocker](https://github.com/crazy-max/WindowsSpyBlocker) and [this tutorial](https://github.com/adolfintel/Windows10-Privacy) for even more Windows 10 tips (thanks u/rudolf323)
+- [Virustotal](https://www.virustotal.com/) let's you upload files and it scans it against multiple antivirus software at once. Very helpful for checking false negatives. Website uses Google Analytics.
 - Did you read the [wiki](https://old.reddit.com/r/privacy/wiki/index) yet? Go do that.

--- a/md/_resources.md
+++ b/md/_resources.md
@@ -33,5 +33,4 @@ Everything you need to become a Privacy Wizard.
 - [Guide for Linux users](https://github.com/wesaphzt/block-all-google) on blocking everything Google at the network level. This can and probably will break other alternatives that rely on Google to serve content. Thanks u/wesaphzt
 - u/wesaphzt also provided [this](https://github.com/pyllyukko/user.js), [this](https://ffprofile.com/), and [this](https://www.privacytools.io/browsers/#about_config) for hardening Firefox.
 - Check out [WindowsSpyBlocker](https://github.com/crazy-max/WindowsSpyBlocker) and [this tutorial](https://github.com/adolfintel/Windows10-Privacy) for even more Windows 10 tips (thanks u/rudolf323)
-- [Virustotal](https://www.virustotal.com/) let's you upload files and it scans it against multiple antivirus software at once. Very helpful for checking false negatives. Website uses Google Analytics.
 - Did you read the [wiki](https://old.reddit.com/r/privacy/wiki/index) yet? Go do that.

--- a/md/_resources.md
+++ b/md/_resources.md
@@ -33,5 +33,5 @@ Everything you need to become a Privacy Wizard.
 - [Guide for Linux users](https://github.com/wesaphzt/block-all-google) on blocking everything Google at the network level. This can and probably will break other alternatives that rely on Google to serve content. Thanks u/wesaphzt
 - u/wesaphzt also provided [this](https://github.com/pyllyukko/user.js), [this](https://ffprofile.com/), and [this](https://www.privacytools.io/browsers/#about_config) for hardening Firefox.
 - Check out [WindowsSpyBlocker](https://github.com/crazy-max/WindowsSpyBlocker) and [this tutorial](https://github.com/adolfintel/Windows10-Privacy) for even more Windows 10 tips (thanks u/rudolf323)
-- [Virustotal](https://www.virustotal.com/) let you upload files and it scans it against multiple antivirus software at once. Very helpful for checking false negatives. Unfortunately, Alphabet Inc owns VirusTotal, but there are no good alternatives.
+- [VirusTotal](https://www.virustotal.com/) lets you upload files and scans them against multiple antivirus programs at once. Very helpful for checking false negatives. Unfortunately Alphabet Inc owns VirusTotal but there are no good alternatives.
 - Did you read the [wiki](https://old.reddit.com/r/privacy/wiki/index) yet? Go do that.


### PR DESCRIPTION
[//]: # ( Every alternative in your pull request MUST have an linked issue)

| Checklist |   |
| --------- | - |
| **I have read the guidelines in [CONTRIBUTING.md]**   | yes |
| Include my name in [CONTRIBUTORS.md]                  | yes |
| Any alternatives in this PR have a linked issue       | no |
| I am affiliated with this alternative (if applicable) | no |

[CONTRIBUTING.md]: ../blob/master/CONTRIBUTING.md
[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md

Quote from https://en.wikipedia.org/wiki/VirusTotal

> VirusTotal is a website created by the Spanish security company Hispasec Sistemas. Launched in June 2004, it was acquired by Google Inc. in September 2012.[2][3] The company's ownership switched in January 2018 to Chronicle, a subsidiary of Alphabet Inc.. 