### PR TITLE
Update degoogle.yml, add clearer description for Nextcloud mail client.

### DIFF
--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -629,11 +629,6 @@ web based products:
       eyes: 9
       text: |
         Privacy focusued email provider. Thanks @petertorelli
-    - name: nextCloud
-      url: https://help.nextcloud.com/t/nextcloud-mail-server/157
-      eyes: null
-      text: |
-        Now also provides an email service (self-hosted). Thanks @je-vv
     - name: Anonymize.com Email
       url: https://anonymize.com/
       eyes: null

--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -629,6 +629,14 @@ web based products:
       eyes: 9
       text: |
         Privacy focusued email provider. Thanks @petertorelli
+    - name: NextCloud
+      url: https://help.nextcloud.com/t/nextcloud-mail-server/157
+      eyes: null
+      text: |
+        Nextcloud provides webmail interface that can be used to access email from various provider. 
+        https://github.com/nextcloud/mail
+        https://github.com/pierre-alain-b/rainloop-nextcloud
+        Thanks @je-vv
     - name: Anonymize.com Email
       url: https://anonymize.com/
       eyes: null

--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -633,10 +633,7 @@ web based products:
       url: https://help.nextcloud.com/t/nextcloud-mail-server/157
       eyes: null
       text: |
-        Nextcloud provides webmail interface that can be used to access email from various provider. 
-        https://github.com/nextcloud/mail
-        https://github.com/pierre-alain-b/rainloop-nextcloud
-        Thanks @je-vv
+        Nextcloud provides a [webmail interface](https://github.com/nextcloud/mail) that can be used to access email from various providers. Thanks @je-vv
     - name: Anonymize.com Email
       url: https://anonymize.com/
       eyes: null


### PR DESCRIPTION
https://github.com/tycrek/degoogle/issues/324

Either edit or remove nextcloud from mail provider. Nextcloud is not a mail server, no apps(plugin) in the Nextcloud provided such function either. What it's capable of is as a mail client. There are it's own mail client and rainloop for nextcloud. Not a mail server. The alternative can be, to change the description:

~Now also provides an email service (self-hosted).~ Thanks @je-vv
Nextcloud only provides webmail interface that can be used to access email from various provider. 
https://github.com/nextcloud/mail
https://github.com/pierre-alain-b/rainloop-nextcloud

[//]: # ( Every alternative in your pull request MUST have an linked issue)

| Checklist |   |
| --------- | - |
| **I have read the guidelines in [CONTRIBUTING.md]**   | yes |
| Include my name in [CONTRIBUTORS.md]                  | no |
| Any alternatives in this PR have a linked issue       | yes |
| I am affiliated with this alternative (if applicable) | no |

[CONTRIBUTING.md]: ../blob/master/CONTRIBUTING.md
[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
