### PR TITLE
Update searx

### DIFF
--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -16,9 +16,9 @@ web based products:
         [Issue #12](https://github.com/tycrek/degoogle/issues/12). Thanks @pydo, @ThijsRay, and @DatAres37.
         Also see [this comment in Issue #99](https://github.com/tycrek/degoogle/issues/99#issuecomment-616224650)
         from @danarel on Startpage.
-    - name: searx.me
-      url: https://searx.me/
-      repo: https://github.com/asciimoo/searx
+    - name: searx
+      url: https://searx.space/
+      repo: https://github.com/searx/searx
       eyes: null
       text: >
         Open-source (thanks for clarification u/Sheezdudeln) privacy search engine. Domain hosted in Germany.


### PR DESCRIPTION
The project is still alive but the domain domain searx.me seams dead.
Change link to the list of running instances retrieved from the official readme of searx.
Link to Github has also changed, swapped the link all tough the old still redirects to the new repository.

I wanted to create an issue but then I decided it would be easier to just go ahead and update the entry myself.

[//]: # ( Every alternative in your pull request MUST have an linked issue)

| Checklist |   |
| --------- | - |
| **I have read the guidelines in [CONTRIBUTING.md]**   | yes |
| Include my name in [CONTRIBUTORS.md]                  | yes |
| Any alternatives in this PR have a linked issue       | no |
| I am affiliated with this alternative (if applicable) | no |

[CONTRIBUTING.md]: ../blob/master/CONTRIBUTING.md
[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
