### PR TITLE
Update available platforms for ente

### DIFF
--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -475,7 +475,7 @@ web based products:
       repo: https://github.com/ente-io/
       eyes: 5
       text: >
-        A paid, cloud-based, open-source mobile and desktop photo storage app with a focus on security and privacy. Apps are available for iOS and Android.
+        A paid, cloud-based, open-source photo storage app with a focus on security and privacy. Apps are available for iOS, Android, web and desktop.
   calendar:
     - title: Calendar
     - name: Lightning Calendar (Thunderbird)


### PR DESCRIPTION
Thank you for adding ente to this list. This change clarifies that ente has apps for (https://github.com/ente-io/bada-frame) and desktop (https://github.com/ente-io/bhari-frame) too.

<!-- If your Pull Request is related to an alternative, make sure there is a corrosponding Issue for discussion. -->

| Checklist |   |
| --------- | - |
| **I have read the guidelines in [CONTRIBUTING.md]**   | yes |
| Include my name in [CONTRIBUTORS.md]                  | yes |
| I am affiliated with this alternative (if applicable) | yes |


### Details
Original issue (closed): https://github.com/tycrek/degoogle/issues/380


[CONTRIBUTING.md]: ../blob/master/CONTRIBUTING.md
[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
