### PR TITLE
Tutanota description completed and Aurora Store added

### DIFF
--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -1676,13 +1676,13 @@ mobile applications:
       url: https://protonmail.com/support/knowledge-base/android/
       eyes: null
       text: >
-        Can be downloaded from the Play Store, but may work with one of the store replacements above (such as Yalp).
+        Can be downloaded from the Play Store, and work with other stores based on the google play store (such as Yalp, Aurora).
     - name: Tutanota
       url: https://www.tutanota.com/
       fdroid: de.tutao.tutanota
       eyes: 14
       text: >
-        Client available from F-Droid.
+        Android notifications fully independant of Google Cloud Messaging / Services. Can be downloaded from the Play Store and F-Droid, and work with other stores based on the google play store (such as Yalp, Aurora).
     - name: Disroot
       url: https://disroot.org/
       fdroid: org.disroot.disrootapp


### PR DESCRIPTION
| Checklist |   |
| --------- | - |
| **I have read the guidelines in [CONTRIBUTING.md]**   | yes |
| Include my name in [CONTRIBUTORS.md]                  | yes |
| I am affiliated with this alternative (if applicable) | N/A |

### Details

Alternative store based on Google Play Store (Aurora and Yalp) are, at this moment, stable. Aurora is very used and it's important to specify that it works well on him.

Add Tutanota notifications system fully independant to Google servers, good point for privacy.