### PR TITLE
Few new additions, removals and fixes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -83,6 +83,7 @@ Thanks to everyone here for contributing in some way! (usernames are in no parti
 - [@itforweb666](https://github.com/itforweb666)
 - [@seanking2919](https://github.com/seanking2919)
 - [@FireMasterK](https://github.com/FireMasterK)
+- [@the-weird-aquarian](https://github.com/the-weird-aquarian)
 
 ### Reddit:
 

--- a/md/_disclaimer.md
+++ b/md/_disclaimer.md
@@ -11,8 +11,8 @@
 | Eyes | Countries |
 | :--: | :---------: |
 | **5** | Australia, Canada, New Zealand, UK, USA |
-| **9** | Denmark, France, Netherlands, Norway |
-| **14** | Germany, Belgium, Italy, Sweden, Spain |
+| **9** | 5 eyes + Denmark, France, Netherlands, Norway |
+| **14** | 9 eyes + Germany, Belgium, Italy, Sweden, Spain |
 
 [wiki]: https://en.wikipedia.org/wiki/List_of_Google_products
 [eyes]: https://restoreprivacy.com/5-eyes-9-eyes-14-eyes/#h-five-eyes

--- a/md/_resources.md
+++ b/md/_resources.md
@@ -8,7 +8,6 @@ Everything you need to become a privacy wizard. This section has two subsections
 - [DuckDuckGo's privacy newsletter](https://duckduckgo.com/newsletter)
 - [EFF's Surveillance Self-Defense (eff.org)](https://ssd.eff.org/)
 - [Everything You Need to Know About Password Managers](https://outline.com/NC69FD)
-- [Firefox: Privacy Related "about:config" Tweaks](https://privacyguides.org/browsers/#about_config)
 - [Four Methods to Create a Secure Password You'll Actually Remember](https://outline.com/XuMTFA)
 - [How to create a strong password (and remember it)](https://outline.com/dqfuqL)
 - [How to delete remembered passwords (WikiHow)](http://www.wikihow.com/Delete-Remembered-Passwords)
@@ -30,6 +29,7 @@ Everything you need to become a privacy wizard. This section has two subsections
 - [What is Tor and should I use it?](https://outline.com/JRCscH)
 - [Why You Really Should Put Tape Over Your Webcam](https://outline.com/fYCu98)
 - [Windows 10 Privacy Guide (fdossena.com)](https://fdossena.com/?p=w10debotnet/index_1903.frag)
+- [Privacy Settings for major softwares](https://github.com/the-weird-aquarian/privacy-settings)
 - [7 Reasons to Use a Third-Party DNS Service](https://outline.com/8jsWXw)
    - Use [DNSPerf](https://www.dnsperf.com/#!dns-resolvers) to see which one is fastest for you.
 

--- a/yaml/browserExtensions.yml
+++ b/yaml/browserExtensions.yml
@@ -26,10 +26,6 @@
   url: https://addons.mozilla.org/en-US/firefox/addon/minerblock-origin
   text: |
     MinerBlock is an efficient browser extension that focuses on blocking browser-based cryptocurrency miners all over the web. This extension uses two different approaches to block miners. The first one is based on blocking requests/scripts loaded from a blacklist, this is the traditional approach adopted by most ad-blockers and other mining blockers. The other approach which makes MinerBlock more efficient against cryptojacking is detecting potential mining behavior inside loaded scripts and kills them immediately. This makes the extension able to block inline scripts as well as miners running through proxies. Source code available on [GitHub](https://github.com/xd4rker/MinerBlock).
-- name: ClearURLS
-  url: https://addons.mozilla.org/en-US/firefox/addon/clearurls
-  text: |
-    This extension will automatically remove tracking elements from URLs to help protect your privacy when browse through the Internet.
 - name: Cloud Firewall
   url: https://addons.mozilla.org/en-US/firefox/addon/cloud-firewall
   text: |
@@ -58,10 +54,6 @@
   url: https://addons.mozilla.org/en-US/firefox/addon/httpz
   text: |
     HTTPZ is meant to be unobtrusive and lightweight, it respects your privacy, and is free of trans fats. Additionally, it is very configurable, and should be slightly more secure than some of the alternatives out there, since it has a couple of built-in defenses against SSL-stripping attacks.
-- name: Link Cleaner
-  url: https://addons.mozilla.org/en-US/firefox/addon/link-cleaner
-  text: |
-    Clean URLs that are about to be visited: removes utm_* parameters; on item pages of aliexpress and amazon, removes tracking parameters; skip redirect pages of facebook, steam and reddit
 - name: Privacy-Oriented Origin Policy
   url: https://addons.mozilla.org/en-US/firefox/addon/privacy-oriented-origin-policy
   text: |

--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -28,16 +28,6 @@ web based products:
       eyes: null
       text: >
         Open-source (thanks for clarification u/Sheezdudeln) privacy search engine. Domain hosted in Germany.
-    - name: MetaGer
-      url: https://metager.org/about
-      eyes: 14
-      text: >
-        MetaGer is the search engine project from the registered nonprofit organization SUMA E.V. in Germany.
-    - name: Qwant
-      url: https://www.qwant.com/
-      eyes: 9
-      text: >
-        A privacy-respecting search engine. **Note:** Qwant may not be available in all countries; see [Issue #408](https://github.com/tycrek/degoogle/issues/408) for more information.
     - name: Swisscows
       url: https://swisscows.ch
       eyes: null
@@ -1107,8 +1097,8 @@ operating systems:
     - title: Android/Fuchsia
     - notes:
         - >
-          You'll either need a rooted device with an unlocked bootloader, or a specific device
-          depending on which OS you like.
+          You'll need a device with an unlocked bootloader.
+        - Some OS only support specific devices.
         - Please see [Issue \#55](https://github.com/tycrek/degoogle/issues/55) for details on /e/.
         - You can use [Plexus](https://plexus.techlore.tech/) to check android app compatibility on degoogled Android operating systems.
     - name: Ubuntu Touch
@@ -1511,6 +1501,13 @@ mobile applications:
       eyes: null
       text: >
         Open-source camera for Android. Thanks @je-vv
+    - name: Simple Camera
+      url: https://github.com/SimpleMobileTools/Simple-Camera
+      repo: https://github.com/SimpleMobileTools/Simple-Camera
+      fdroid: https://f-droid.org/packages/com.simplemobiletools.camera/
+      eyes: null
+      text: > 
+        Quick photo and video camera with a flash, customizable resolution and no ads. 
   clock:
     - title: Clock
     - name: Clock +
@@ -1543,6 +1540,28 @@ mobile applications:
       text: >
         An open-source simple alarm clock that implements many useful features while following regular
         design standards to ensure that it is quick and intuitive to use.
+  files:
+    - title: Files
+    - name: Material Files
+      url: https://github.com/zhanghai/MaterialFiles
+      repo: https://github.com/zhanghai/MaterialFiles
+      fdroid: https://f-droid.org/packages/me.zhanghai.android.files/
+      eyes: null
+      text: >
+        An open source Material Design file manager, for Android 5.0+.
+    - name: Amaze File Manager
+      url: https://github.com/TeamAmaze/AmazeFileManager
+      repo: https://github.com/TeamAmaze/AmazeFileManager
+      eyes: null
+      text: >
+        Material design file manager for Android 
+    - name: Simple File Manager
+      url: https://github.com/SimpleMobileTools/Simple-File-Manager
+      repo: https://github.com/SimpleMobileTools/Simple-File-Manager
+      fdroid: https://f-droid.org/packages/com.simplemobiletools.filemanager.pro/
+      eyes: null
+      text: >
+        A simple file manager for browsing and editing files and directories. 
   contacts:
     - title: Contacts
     - name: Fruux (mobile app)
@@ -1564,6 +1583,21 @@ mobile applications:
       eyes: null
       text: >
         Open-source contacts. (thanks u/consentio)
+  dialer:
+    - title: Dialer
+    - name: Koler
+      url: https://github.com/Chooloo/koler
+      repo: https://github.com/Chooloo/koler
+      eyes: null
+      text: >
+        Koler is a uniquely stylized phone app for Android, designed with the user in mind
+    - name: Simple Dialer
+      url: https://github.com/SimpleMobileTools/Simple-Dialer
+      repo: https://github.com/SimpleMobileTools/Simple-Dialer
+      fdroid: https://f-droid.org/packages/com.simplemobiletools.dialer/
+      eyes: null
+      text: >
+        A handy phone call manager with phonebook, number blocking and multi-SIM support 
   messages:
     - title: Android Messages (specifically SMS/MMS, not IM)
     - name: QKSMS
@@ -1791,7 +1825,14 @@ mobile applications:
       eyes: null
       text: >
         A truly zero-knowledge note taking app, encrypted using XChaChaPoly1305-IETF & Argon2. It is available on Windows, macOS, Linux, Android, iOS, and has browser extensions too. It is not self-hostable and follows a freemium model. Downloads are available on [Google Play](https://play.google.com/store/apps/details?id=com.streetwriters.notesnook) and the iOS [App Store](https://apps.apple.com/us/app/notesnook/id1544027013).
-  maps and waze:
+    - name: Quillnote
+      url: https://qosp.org/#/
+      repo: https://github.com/msoultanidis/quillnote
+      fdroid: https://f-droid.org/packages/org.qosp.notes/
+      eyes: null
+      text: >
+        Take beautiful markdown notes and stay organized with task lists.
+  maps and waze: 
     - title: Maps/Waze
     - name: Maps
       url: https://gitlab.com/axet/omim/-/blob/HEAD/README.md
@@ -1953,6 +1994,19 @@ mobile applications:
       eyes: null
       text: >
         Open-source local music player for Android. Available on F-Droid or by direct download.
+    - name: Metro
+      url: https://github.com/MuntashirAkon/Metro
+      repo: https://github.com/MuntashirAkon/Metro
+      fdroid: https://f-droid.org/en/packages/io.github.muntashirakon.Music/
+      eyes: null
+      text: >
+        Metro is a fork of Retro Music with Google Play API removed and all pro features unlocked.
+    - name: Vinyl Music Player
+      url: https://adrien.poupa.fr/introducing-vinyl-music-player/
+      repo: https://github.com/AdrienPoupa/VinylMusicPlayer
+      eyes: null
+      text: >
+        A material designed local music player for Android. Forked from Phonograph; makes all Pro features free.
   hangouts:
     - title: Hangouts
     - name: Keybase
@@ -2108,6 +2162,27 @@ mobile applications:
       eyes: null
       text: >
         A clean, simple Android launcher with a very minimalist design. Forked from [Slim Launcher](https://github.com/sduduzog/slim-launcher).
+    - name: Posidon Launcher
+      url: https://posidon.io/launcher
+      repo: https://github.com/lposidon/posidonLauncher
+      fdroid: https://www.f-droid.org/packages/posidon.launcher/
+      eyes: null
+      text: >
+        Posidon launcher is a minimal, one page homescreen with a vertical scrolling feed.
+    - name: Pie Launcher
+      url: https://github.com/markusfisch/PieLauncher
+      repo: https://github.com/markusfisch/PieLauncher
+      fdroid: https://f-droid.org/de/packages/de.markusfisch.android.pielauncher/
+      eyes: null
+      text: >
+        Android home screen launcher that uses a dynamic pie menu instead of fixed positioned icons.
+    - name: Olauncher
+      url: https://github.com/tanujnotes/Olauncher
+      repo: https://github.com/tanujnotes/Olauncher
+      fdroid: https://f-droid.org/packages/app.olauncher
+      eyes: null
+      text: >
+        Olauncher is a minimal ad-free launcher app for Android with daily new wallpaper.
   other:
     - title: "*Other*"
     - name: Blokada
@@ -2137,6 +2212,17 @@ mobile applications:
       text: >
         From the website: "Rethink DNS + Firewall is the easiest way to monitor app activity, circumvent
         Internet censorship, block ads and trackers on your Android device."
+    - name: NetGuard
+      url: https://netguard.me/
+      repo: https://github.com/M66B/NetGuard
+      eyes: null
+      text: >
+        A simple way to block access to the internet per app without root.
+    - name: Orbot
+      url: https://guardianproject.info/apps/org.torproject.android/
+      repo: https://github.com/guardianproject/orbot
+      text: >
+        Orbot is a free proxy app that empowers other apps to use the internet more securely. Orbot uses Tor to encrypt your Internet traffic and then hides it by bouncing through a series of computers around the world.
     - name: TrackerControl
       url: https://github.com/OxfordHCC/tracker-control-android
       repo: https://github.com/OxfordHCC/tracker-control-android


### PR DESCRIPTION
| Checklist |   |
| --------- | - |
| **I have read the guidelines in [CONTRIBUTING.md]**   | yes |
| Include my name in [CONTRIBUTORS.md]                  | yes |
| I am affiliated with this alternative (if applicable) | no |


# Details



## Browser extensions
- removed ClearURLS and Link Cleaner as the same functionality is now achieved using [removeparam](https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#removeparam) feature in ublock origin.

**How to**: 
In Filter lists
1. Enable AdGuard URL Tracking Protection under Privacy.
2. Under Custom, select import and paste the following URL in the field given below
https://raw.githubusercontent.com/DandelionSprout/adfilt/master/LegitimateURLShortener.txt



## Web-based products

#### Search (Web & Images)
- removed qwant as  data is collected and shared with third parties
https://about.qwant.com/en/legal/confidentialite/
https://tosdr.org/en/service/527

- removed metager due to personalized ads and possible censorship
https://metager.org/datenschutz
https://tosdr.org/en/service/2658



## Operating systems

#### Android/Fuchsia
- fixed info for device requirements of custom roms. Root is not required for flashing custom roms.



## Mobile apps

#### Camera
- added Simple Camera

#### Dialer
- added this new section with alternatives

#### Files
- added this new section with alternatives

#### Play Music/Play Movies & TV
- added Metro and Vinyl Music Player

#### Android home screen launchers
- added Posidon Launcher, Pie Launcher and Olauncher

#### Other
- added NetGuard and Orbot



## Useful links, tools, and advice

#### Resources
- removed Privacy Guides about:config tweaks link. They now themselves suggest to use [arkenfox user.js](https://github.com/arkenfox/user.js). More info regarding this [here](https://privacyguides.org/blog/2021/12/01/firefox-privacy-2021-update/).

- added [Privacy Settings for major softwares](https://github.com/the-weird-aquarian/privacy-settings). My own repo guiding all privacy related settings on most major softwares and services, updated regularly. More softwares and services would be added soon.



## Some other stuff
This section discusses some stuff that could be done but I didn't.

- HTTPS Everywhere in Browser extensions: could be removed as all major browsers by default use https connections now & include the same in settings. Also it would be deprecated anyway very soon.

- Privacy Badger in Browser extensions: would have removed privacy badger, however [#issue426](https://github.com/tycrek/degoogle/issues/426) already exists with all links I wanted to mention but looks like there might be a possible disagreement going on. It's your repo so feel free to make your own decision. :)

- Swisscows in Search (Web & Images) : couldn't figure out what to do with this, as according to their [privacy policy](https://swisscows.com/en/privacy), they log personal data like IP addresses, user agent etc, stores them for 7 days and then deletes them. Maybe include a note for all users to be informed about the same?

- DuckDuckGo Maps in Maps/Street View: could have added but as stated here in [#issue369](https://github.com/tycrek/degoogle/issues/369) a direct link is required. Only way to access it is searching something using DuckDuckGo and clicking Maps on top. DuckDuckGo has designed it this way without any direct url and hence nothing can be done about it.


