### PR TITLE
Remove "Don't touch my tabs! (rel=noopener)"

### DIFF
--- a/yaml/browserExtensions.yml
+++ b/yaml/browserExtensions.yml
@@ -42,10 +42,6 @@
   url: https://addons.mozilla.org/en-US/firefox/addon/disconnect
   text: |
     Visualize and block the otherwise invisible websites that track your search and browsing history.
-- name: Don't touch my tabs! (rel=noopener
-  url: https://addons.mozilla.org/en-US/firefox/addon/dont-touch-my-tabs
-  text: |
-    Prevent tabs opened by a hyperlink from hijacking the previous tab by adding the rel=noopener attribute to all hyperlinks (excluding same-domain hyperlinks).
 - name: Firefox Multi-Account Containers
   url: https://addons.mozilla.org/en-US/firefox/addon/multi-account-containers
   text: |


### PR DESCRIPTION
The add-on is no longer available at https://addons.mozilla.org/en-US/firefox/addon/dont-touch-my-tabs/

<!-- If your Pull Request is related to an alternative, make sure there is a corresponding Issue for discussion. -->

| Checklist |   |
| --------- | - |
| **I have read the guidelines in [CONTRIBUTING.md]**   | yes |
| Include my name in [CONTRIBUTORS.md]                  | yes |
| I am affiliated with this alternative (if applicable) | no |


### Details
<!-- Optional if details exist in a linked Issue. If that is the case, link to the Issue here. -->


[CONTRIBUTING.md]: ../blob/master/CONTRIBUTING.md
[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
