### PR TITLE
remove CTemplar from list of email providers

### DIFF
--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -876,11 +876,6 @@ web based products:
         with editing space. Offers free, paid, and freemium plans. Can pay with cryptocurrency and
         has a [warrant canary](https://blog.mailfence.com/transparency-report-and-warrant-canary/).
         Thanks @resto1231
-    - name: CTemplar
-      url: https://ctemplar.com/
-      eyes: null
-      text: >
-        Privacy-focused email provider located in Iceland.
     - name: Anonaddy
       url: https://anonaddy.com/
       repo: https://github.com/anonaddy/anonaddy


### PR DESCRIPTION
<!-- If your Pull Request is related to an alternative, make sure there is a corresponding Issue for discussion. -->

| Checklist |   |
| --------- | - |
| **I have read the guidelines in [CONTRIBUTING.md]**   | yes |
| Include my name in [CONTRIBUTORS.md]                  | no |
| I am affiliated with this alternative (if applicable) | no |


### Details
<!-- Optional if details exist in a linked Issue. If that is the case, link to the Issue here. -->

> CTemplar is closing and the last day of operation for this email service will be on May 26 of 2022.

Directly quoted from this CTemplar blog post: https://ctemplar.com/ctemplar-is-shutting-down/


[CONTRIBUTING.md]: ../blob/master/CONTRIBUTING.md
[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
