### PR TITLE
Signal for SMS remove

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -86,6 +86,7 @@ Thanks to everyone here for contributing in some way! (usernames are in no parti
 - [@julianfairfax](https://github.com/julianfairfax)
 - [@ACK-J](https://github.com/ACK-J)
 - [@joebudi](https://github.com/joebudi)
+- [@namelessperson0](https://github.com/namelessperson0)
 
 ### Reddit:
 

--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -1585,16 +1585,6 @@ mobile applications:
       text: >
         Open-source and utilizes Signal's encryption protocol. Seamlessly works with SMS. End-to-end
         encryption with other Silence users. Available on F-Droid.
-    - name: Signal
-      url: https://signal.org/
-      repo: https://github.com/signalapp
-      eyes: null
-      text: >
-        Open-source. Signal possesses SMS/MMS capabilities on Android. Using it as your default SMS
-        app has the advantage of having your SMS and your online-messaging-service integrated within
-        one app. Doing so will also show stats within the app of how many messages you send are encrypted,
-        and offers to send invites to your contacts.<br/><br/>Thanks @Glitchy-Tozier for suggesting it be
-        listing as SMS/MMS alternative.
   gboard:
     - title: Gboard (Google Keyboard)
     - name: AnySoftKeyboard


### PR DESCRIPTION

| Checklist |   |
| --------- | - |
| **I have read the guidelines in [CONTRIBUTING.md]**   | yes |
| Include my name in [CONTRIBUTORS.md]                  | yes|
| I am affiliated with this alternative (if applicable) | No |

Remove Signal from SMS section as Signal is stopping support for SMS. Reference https://www.signal.org/blog/sms-removal-android