### PR TITLE
Multiple (5) changes...

### DIFF
--- a/yaml/browserExtensions.yml
+++ b/yaml/browserExtensions.yml
@@ -86,3 +86,7 @@
   url: https://addons.mozilla.org/en-US/firefox/addon/port-authority/
   text: |
     Blocks websites from using javascript to port scan your computer/network and dynamically blocks all LexisNexis endpoints from running their invasive data collection scripts. [Website](https://www.g666gle.me/Port-Authority/), [Source Code](https://github.com/ACK-J/Port_Authority)
+- name: CanvasBlocker
+  url: https://github.com/kkapsner/CanvasBlocker
+  text: |
+    Removes fingerprint tracking from JavaScript APIs and WebGL.

--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -1295,6 +1295,11 @@ desktop applications:
         development. Looks very clean and fast. Android versions are in the works too.
         **UPDATE:** @Nudin pointed out in [Issue \#85](https://github.com/tycrek/degoogle/issues/85) that Waterfox is now
         [a part of System1](https://www.waterfox.net/blog/waterfox-has-joined-system1/).
+    - name: Mullvad Browser
+      url: https://mullvad.net/en/browser/
+      eyes: null
+      text: >
+        Firefox-based, a collaboration between Mullvad and The Tor Project. Similar to Tor Browser in privacy and security, without the use of the Tor network.
   earth:
     - title: Earth
     - name: KDE Marble
@@ -1322,16 +1327,6 @@ desktop applications:
       eyes: null
       text: >
         Another open-source text editor. Thanks @moon-chilled
-    - name: Atom
-      url: https://atom.io/
-      repo: https://github.com/atom/atom
-      eyes: null
-      text: >
-        Atom is a free and open-source text and source code editor for macOS, Linux, and Microsoft
-        Windows with support for plug-ins written in Node.js, and embedded Git Control, developed by
-        GitHub. Atom is a desktop application built using web technologies.
-        (From [Wikipedia](https://en.wikipedia.org/wiki/Atom_(text_editor)))
-        Thanks @woutfeys
 flutter:
   - title: flutter cross platform development tool for iOS/Android etc. based on Dart
   - name: Apache Cordova
@@ -1365,22 +1360,6 @@ mobile applications:
       text: >
         Catalogue of FOSS apps for Android. Easy to install and keeps track of updates. Also has a
         browser version if you don't want to install the app.
-    - name: Yalp Store (fork)
-      url: https://github.com/kiliakin/YalpStore
-      repo: https://github.com/kiliakin/YalpStore
-      fdroid: com.github.kiliakin.yalpstore
-      eyes: null
-      text: >
-        Yalp downloads Play Store apps as APK files. Helpful if you want to stay away from the Play
-        Store, but require an app that is only available there. This version is a fork of the original
-        project that is no longer active.
-        Thank @onlyjob
-    - name: APKMirror
-      url: https://www.apkmirror.com/
-      eyes: null
-      text: >
-        An online library of user-uploaded APK files. Helpful if you need a specific older version
-        of an app or don't want to download it through Google Play.
     - name: Aurora Store
       url: https://gitlab.com/AuroraOSS/AuroraStore
       repo: https://gitlab.com/AuroraOSS/AuroraStore
@@ -1392,6 +1371,12 @@ mobile applications:
         **Update:** Removed note on using microG as Aurora Store
         [does not use it](https://gitlab.com/AuroraOSS/AuroraStore/-/blob/master/README.md#L77).
         Thanks @notpushkin
+    - name: APKMirror
+      url: https://www.apkmirror.com/
+      eyes: null
+      text: >
+        An online library of user-uploaded APK files. Helpful if you need a specific older version
+        of an app or don't want to download it through Google Play.
     - name: Fossdroid
       url: https://fossdroid.com/
       eyes: null


### PR DESCRIPTION
<!-- If your Pull Request is related to an alternative, make sure there is a corresponding Issue for discussion. -->

| Checklist |   |
| --------- | - |
| **I have read the guidelines in [CONTRIBUTING.md]**   | yes |
| Include my name in [CONTRIBUTORS.md]                  | no |
| I am affiliated with this alternative (if applicable) | no |


### Details
<!-- Optional if details exist in a linked Issue. If that is the case, link to the Issue here. -->

- Added [Mullvad Browser](https://mullvad.net/en/browser) to replacements/alternatives to Chrome (desktop).
- Removed Atom from IDEs, since it's no longer being developed (archived)[^1].
- Removed Yalp Store from Android app stores, since it's no longer being developed (stale)[^2].
- Moved Aurora Store to below F-Droid, above APKMirror.
- Added [CanvasBlocker](https://github.com/kkapsner/CanvasBlocker) to browser extensions.

[CONTRIBUTING.md]: ../blob/master/CONTRIBUTING.md
[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[^1]: https://github.blog/2022-06-08-sunsetting-atom/
[^2]: Last commit was in October 2018, [view source code here](https://github.com/yeriomin/YalpStore).