### PR TITLE
Fix link and description for Migadu

### DIFF
--- a/yaml/degoogle.yml
+++ b/yaml/degoogle.yml
@@ -839,10 +839,10 @@ web based products:
       text: >
         Open-source, self-hosted, and privacy focused email forwarding service.
     - name: Migadu
-      url: https://www.migadu.com/en/index.html
+      url: https://www.migadu.com
       eyes: 9
       text: >
-        Paid email provider, located in Switzerland. Focus on privacy.
+        Paid email provider, run from Switzerland with servers in France. Focus on privacy.
     - name: Fastmail
       url: https://fastmail.com/
       eyes: 5


### PR DESCRIPTION
I fixed the URL to the home page, which went to 404. I also clarified the location of the service according to their [Pro/Cons](https://www.migadu.com/procon/) page:

    In Switzerland, but servers are not

    This may come as a surprise, but we do not host our servers
    in Switzerland. Current data centers are located in France.
    We may in the near future add Swiss data centers too but
    this is not our priority.

    We find EU privacy laws much more elaborate and restrictive
    than the Swiss ones. Switzerland used to be famous for
    banking secrecy, but that has nothing to do with digital data.

<!-- If your Pull Request is related to an alternative, make sure there is a corresponding Issue for discussion. -->

| Checklist |   |
| --------- | - |
| **I have read the guidelines in [CONTRIBUTING.md]**   | yes |
| Include my name in [CONTRIBUTORS.md]                  | no |
| I am affiliated with this alternative (if applicable) | no |


### Details
<!-- Optional if details exist in a linked Issue. If that is the case, link to the Issue here. -->


[CONTRIBUTING.md]: ../blob/master/CONTRIBUTING.md
[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
